### PR TITLE
Update datasets rst to reflect height->years change

### DIFF
--- a/WWW/data/index.rst
+++ b/WWW/data/index.rst
@@ -35,13 +35,13 @@ Fields:
 dataset_scale.csv
 ---------------
 
-Mocked-up data for examining the relationship between height and salary.
+Mocked-up data for examining the relationship between salary and years of experience.
 
 :download:`Click to download data </datasets/dataset_scale.csv>`
 
 Fields:
 
-* **height**: Participant's height
+* **years**: Years that participant has worked
 * **salary**: Participant's salary
 
 


### PR DESCRIPTION
We changed `dataset_scale.csv` to use years instead of height. This PR updates the dataset page of the site to reflect this
